### PR TITLE
Expose wallet2::{en,de}crypt in monero_wallet_full

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,7 +240,9 @@ set_target_properties(version PROPERTIES IMPORTED_LOCATION
 add_library(randomx STATIC IMPORTED)
 set_target_properties(randomx PROPERTIES IMPORTED_LOCATION
     ${MONERO_PROJECT_BUILD}/external/randomx/librandomx.a)
-    
+
+find_library (ZMQ_LIBRARY NAMES zmq REQUIRED)
+
 ########################
 # Build c++ library
 ########################
@@ -293,6 +295,7 @@ if (BUILD_LIBRARY)
         ${OPENSSL_LIBRARIES}
         ${SODIUM_LIBRARY}
         ${HIDAPI_LIBRARIES}
+        ${ZMQ_LIBRARY}
         ${EXTRA_LIBRARIES}
     )
 endif()
@@ -340,6 +343,7 @@ if (BUILD_SAMPLE)
         ${OPENSSL_LIBRARIES}
         ${SODIUM_LIBRARY}
         ${HIDAPI_LIBRARIES}
+        ${ZMQ_LIBRARY}
         ${EXTRA_LIBRARIES}
     )
 endif()
@@ -387,6 +391,7 @@ if (BUILD_SCRATCHPAD)
         ${OPENSSL_LIBRARIES}
         ${SODIUM_LIBRARY}
         ${HIDAPI_LIBRARIES}
+        ${ZMQ_LIBRARY}
         ${EXTRA_LIBRARIES}
     )
 endif()

--- a/src/wallet/monero_wallet.h
+++ b/src/wallet/monero_wallet.h
@@ -968,6 +968,30 @@ namespace monero {
     }
 
     /**
+     * Encrypt a message.
+     *
+     * @param plaintext - the message to sign
+     * @param[in,out] pad - the number of characters appended to the plaintext so that the length is divisible 4 (required for decryption)
+     * @param[in] authenticated - true to also sign the message
+     * @return the encrypted message
+     */
+    virtual std::string encrypt_message(const std::string& plaintext, uint64_t& pad, bool authenticated = true) const {
+      throw std::runtime_error("encrypt_message() not supported");
+    }
+
+    /**
+     * Decrypt a message.
+     *
+     * @param ciphertext_z85 - the encrypted message encoded in z85 format
+     * @param[in] pad - the number of characters appended to the plaintext before encryption
+     * @param[in] authenticated - true to also verify the message authenticity
+     * @return the decrypted message
+     */
+    virtual std::string decrypt_message(const std::string& ciphertext_z85, uint64_t pad, bool authenticated = true) const {
+      throw std::runtime_error("decrypt_message() not supported");
+    }
+
+    /**
      * Get a transaction's secret key from its hash.
      *
      * @param tx_hash is the transaction's hash

--- a/src/wallet/monero_wallet_full.h
+++ b/src/wallet/monero_wallet_full.h
@@ -241,6 +241,8 @@ namespace monero {
     std::vector<std::string> submit_txs(const std::string& signed_tx_hex) override;
     std::string sign_message(const std::string& msg, monero_message_signature_type signature_type, uint32_t account_idx = 0, uint32_t subaddress_idx = 0) const override;
     monero_message_signature_result verify_message(const std::string& msg, const std::string& address, const std::string& signature) const override;
+    std::string encrypt_message(const std::string& plaintext, uint64_t& pad, bool authenticated) const override;
+    std::string decrypt_message(const std::string& ciphertext_z85, uint64_t pad, bool authenticated) const override;
     std::string get_tx_key(const std::string& tx_hash) const override;
     std::shared_ptr<monero_check_tx> check_tx_key(const std::string& tx_hash, const std::string& txKey, const std::string& address) const override;
     std::string get_tx_proof(const std::string& tx_hash, const std::string& address, const std::string& message) const override;


### PR DESCRIPTION
This will only work after https://github.com/monero-project/monero/pull/8515 is merged and integrated here, so after review the API might change. I tested this using:
```cpp
auto w = monero_wallet_full::create_wallet_random( "", "", monero_network_type::TESTNET );
for (const auto& text : std::array<std::string,4>{"Restricted","Restricted0","Restricted01","Restricted012"}) {
    for (auto authenticated : std::array<bool,2>{false,true}) {
      uint64_t pad;
      auto ciphertext_z85 = w->encrypt_message( text, pad, authenticated );
      auto cleartext = w->decrypt_message( ciphertext_z85, pad, authenticated );
      std::cout << "'" << text << "', " << authenticated << ", " << ciphertext_z85 << ", " << pad << ", '" << cleartext << "'\n";
      assert( text == cleartext );
    }
  }
```

Please let me know how I can help integrate this better.