### PR TITLE
Change Access Level of m_w2 field in monero_wallet_full class

### DIFF
--- a/src/wallet/monero_wallet_full.h
+++ b/src/wallet/monero_wallet_full.h
@@ -255,7 +255,7 @@ namespace monero {
   // --------------------------------- PROTECTED --------------------------------
 
   protected:
-      std::unique_ptr<tools::wallet2> m_w2;            // internal wallet implementation
+    std::unique_ptr<tools::wallet2> m_w2;            // internal wallet implementation
 
   // ---------------------------------- PRIVATE ---------------------------------
 

--- a/src/wallet/monero_wallet_full.h
+++ b/src/wallet/monero_wallet_full.h
@@ -252,11 +252,15 @@ namespace monero {
     std::string get_keys_file_buffer(const epee::wipeable_string& password, bool view_only) const;
     std::string get_cache_file_buffer() const;
 
+  // --------------------------------- PROTECTED --------------------------------
+
+  protected:
+      std::unique_ptr<tools::wallet2> m_w2;            // internal wallet implementation
+
   // ---------------------------------- PRIVATE ---------------------------------
 
   private:
     friend struct wallet2_listener;
-    std::unique_ptr<tools::wallet2> m_w2;            // internal wallet implementation
     std::unique_ptr<wallet2_listener> m_w2_listener; // internal wallet implementation listener
     std::set<monero_wallet_listener*> m_listeners;   // external wallet listeners
 


### PR DESCRIPTION
Access level of m_w2 field in monero_wallet_full class changed from private to protected to improve extendability for subclasses.

Thank you for considering!