### PR TITLE
Access Level of init_common method in monero_wallet_full changed to p…

### DIFF
--- a/src/wallet/monero_wallet_full.h
+++ b/src/wallet/monero_wallet_full.h
@@ -257,6 +257,8 @@ namespace monero {
   protected:
     std::unique_ptr<tools::wallet2> m_w2;            // internal wallet implementation
 
+    void init_common();
+
   // ---------------------------------- PRIVATE ---------------------------------
 
   private:
@@ -268,7 +270,6 @@ namespace monero {
     static monero_wallet_full* create_wallet_from_keys(monero_wallet_config& config, std::unique_ptr<epee::net_utils::http::http_client_factory> http_client_factory);
     static monero_wallet_full* create_wallet_random(monero_wallet_config& config, std::unique_ptr<epee::net_utils::http::http_client_factory> http_client_factory);
 
-    void init_common();
     std::vector<monero_subaddress> get_subaddresses_aux(uint32_t account_idx, const std::vector<uint32_t>& subaddress_indices, const std::vector<tools::wallet2::transfer_details>& transfers) const;
     std::vector<std::shared_ptr<monero_transfer>> get_transfers_aux(const monero_transfer_query& query) const;
     std::vector<std::shared_ptr<monero_output_wallet>> get_outputs_aux(const monero_output_query& query) const;


### PR DESCRIPTION
Adding to the previous pull request: https://github.com/monero-ecosystem/monero-cpp/pull/41

As before, changing access to the init_common method to **protected**.